### PR TITLE
Tiny fix for obuild to print all missing dependencies at once

### DIFF
--- a/ext/fugue.ml
+++ b/ext/fugue.ml
@@ -208,3 +208,11 @@ let user_int_of_string loc s =
 
 let user_bool_of_string loc s =
     try bool_of_string s with _ -> raise (ConversionBoolFailed (loc,s))
+
+module StringSet = struct
+  include Set.Make(struct
+    type t = string
+    let compare = Pervasives.compare
+  end)
+  let to_list t = fold (fun elt l -> elt::l) t []
+end 

--- a/obuild/dependencies.ml
+++ b/obuild/dependencies.ml
@@ -9,6 +9,7 @@ exception BuildDepAnalyzeFailed of string
 exception BuildCDepAnalyzeFailed of string
 
 exception DependencyMissing of string
+exception DepenenciesMissing of string list
 exception DependencyFailedParsing of string
 
 type dep_constraint = Expr.expr

--- a/obuild/exception.ml
+++ b/obuild/exception.ml
@@ -64,7 +64,12 @@ let show exn =
     | Build.CCompilationFailed e      -> eprintf "\n%s\n%!" e; exit 6
     | Buildprogs.LinkingFailed e           -> eprintf "\n%s\n%!" e; exit 7
     | Dependencies.BuildDepAnalyzeFailed e -> eprintf "\n%s" e; exit 8
-    | Dependencies.DependencyMissing e     -> error "missing dependency '%s'\n" e; exit 9
+    | Dependencies.DepenenciesMissing missing ->
+        begin match List.length missing with
+        | 0 -> assert false
+        | 1 -> error "missing dependency '%s'\n" (List.hd missing); exit 9
+        | _ -> eprintf "missing dependencies:\n%s\n" (Utils.showList "\n" (fun x -> x) missing); exit 9
+        end 
     (* others exception *)
     | Unix.Unix_error (err, fname, params) ->
         error "unexpected unix error: \"%s\" during %s(%s)\n" (Unix.error_message err) fname params;


### PR DESCRIPTION
I'm trying out obuild on a few projects of mine and the current behaviour is a little annoying. That is, giving up on the first not found dependency. I've implemented a tiny fix to make obuild a little more helpful. 

I'm unfamiliar with the codebase/your style so I tried to make the change as unintrusive as possible. So feel free to tell me if something needs to be changed. 
