### PR TITLE
Subcommand argument parsing regression fix

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -356,7 +356,7 @@ let defaultMain () =
         exit 1
     );
 
-    let cmd = List.nth args 0 in
+    let cmd = List.hd args in
     try
         let mainF = List.assoc cmd knownCommands in
         mainF args


### PR DESCRIPTION
You can't leave off the first argument if you intend to parse with `Arg.parse_argv`. Because it is assumed to be the program name and hence ignored automatically.
