### PR TITLE
Fix bytecode linking issue when using C libraries/bindings

### DIFF
--- a/obuild/buildprogs.ml
+++ b/obuild/buildprogs.ml
@@ -142,7 +142,11 @@ let runOcamlLinking includeDirs buildMode linkingMode compileType useThread ccli
                 | WithProf  -> ["-p"])
              @ (Utils.to_include_path_options includeDirs)
              @ (List.map fp_to_string libs)
-             @ (List.concat (List.map (fun x -> [ "-cclib"; x ]) cclibs))
+             @ (List.concat (List.map (fun x ->
+               [ (match buildMode with
+                 | Native -> "-cclib"
+                 | ByteCode -> if x.[1] = 'L' then "-cclib" else "-dllib") (* Ugly hack but do the job for now *)
+               ; x ]) cclibs))
              @ (List.map fp_to_string $ List.map (cmc_of_hier buildMode) modules)
              in
     match run_with_outputs args with


### PR DESCRIPTION
When creating bytecode libraries/executables in dynamic linking mode (i.e. NOT custom mode), only the -dllib option is taken into account. This patch enable the use of -dllib instead of -cclib when linking bytecode libraries/executables, but ONLY if the thing to be passed as a argument is a -lsomething (-dllib refuses -L/path/to/something). If the thing to be passed as argument is -L/path/to/something, the command line argument -cclib -L/path/to/something is still passed to ocamlc, but is ignored by it, so it is harmless and enables this patch to fix the issue with a minimum of modification in the logic of the code.

The linking logic of obuild should be refactored in the future to allow to choose between dynamic and static linking, and do the correct actions accordingly.
