### PR TITLE
Fix the bootstrap script

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 libs="unix.cmxa"
 OCAMLOPT="ocamlopt.opt -g"


### PR DESCRIPTION
I could not build `obuild` via OPAM on my FreeBSD system, so I added a minor tweak to the script that should work even bash in not part of the base system.
