### PR TITLE
Execute ocamldep on .mli too.

### DIFF
--- a/obuild/dependencies.ml
+++ b/obuild/dependencies.ml
@@ -43,10 +43,11 @@ let runOcamldep dopt srcFile =
         try wrap_module f
         with _ -> raise (BuildDepAnalyzeFailed ("ocamldep returned a bad module name " ^ f))
         in
+    let mlFile = fp_to_string srcFile in
     let args = [Prog.getOcamlDep ()]
              @ (Utils.to_include_path_options dopt.dep_includes)
              @ (Pp.pp_to_params dopt.dep_pp)
-             @ ["-modules"; fp_to_string srcFile ] in
+             @ ["-modules"; mlFile; mlFile ^ "i"] in
     match Process.run_with_outputs args with
     | Process.Failure er -> raise (BuildDepAnalyzeFailed er)
     | Process.Success (out,_) ->

--- a/obuild/prepare.ml
+++ b/obuild/prepare.ml
@@ -287,6 +287,7 @@ let get_modules_desc bstate target toplevelModules =
                     let allDeps =
                         match runOcamldep dopt srcFile with
                         | []   -> raise ModuleDependencyNoOutput
+                        | ml::mli::_ -> list_uniq (ml @ mli)
                         | x::_ -> x
                         in
                     verbose Debug "  %s depends on %s\n%!" moduleName (String.concat "," (List.map modname_to_string allDeps));


### PR DESCRIPTION
This commit solves the problem when the .mli and .ml have different dependancies due to over generalization of the type inference.

Note: ocamldep ignores missing files, therefore it doesn't hurt to put the .mli file even if it doesn't exist.
