### PR TITLE
Fix the order problem of required libraries in META.

### DIFF
--- a/obuild/meta.ml
+++ b/obuild/meta.ml
@@ -240,7 +240,7 @@ let parse name content =
             let deps = List.map (fun r -> lib_name_of_string r)
                 $ (List.filter (fun x -> x <> "") $ string_split_pred (fun c -> List.mem c [',';' ']) reqs)
                 in
-            ((mpreds, deps), xs)
+            ((mpreds, (List.rev deps)), xs)
         | _ ->
             metaFailed ("expecting '+=' or '=' after requires")
         in


### PR DESCRIPTION
It essentially revert the negative effect of List.rev in
Analyze.get_pkg_deps.

This one _really_ fix the problem with oUnit2 without breaking vxs.

Signed-off-by: Jerome Maloberti jmaloberti@gmail.com
