### PR TITLE
Version number is injected from obuild.obuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.cmi
 dist
 src/obuild
+src/version.ml

--- a/bootstrap
+++ b/bootstrap
@@ -5,7 +5,7 @@ OCAMLOPT="ocamlopt.opt -g"
 
 extmodules="fugue filepath filesystem"
 libmodules="gconf types dag taskdep dagutils filetype modname hier expr pp utils helper process findlibConf prog dependencies target project meta dist analyze configure prepare buildprogs build exception"
-mainmodules="sdist doc init help install main"
+mainmodules="sdist doc init help install version main"
 
 set -e
 
@@ -72,6 +72,7 @@ rm -f *.cmi *.o *a *.cmx *.cmxa
 
 # rebuild everything with the bootstraped version
 export OCAMLRUNPARAM=b
+./obuild.bootstrap get version | tr . ' ' | awk '{print "let major = ", $1, "\nand minor = ", $2, "\nand micro = ", $3, "\n"}' - > src/version.ml
 ./obuild.bootstrap clean
 ./obuild.bootstrap configure
 time ./obuild.bootstrap build

--- a/src/main.ml
+++ b/src/main.ml
@@ -7,9 +7,6 @@ open Obuild.Helper
 open Obuild.Gconf
 open Obuild
 
-let major = 0
-let minor = 0
-
 let programName = "obuild"
 let usageStr cmd = "\nusage: " ^ programName ^ " " ^ cmd ^ " <options>\n\noptions:\n"
 
@@ -297,7 +294,7 @@ let mainHelp argv =
  * <exe> -opt1 -opt2 <command> <...>
  * *)
 let parseGlobalArgs () =
-    let printVersion () = printf "obuild %d.%d\n" major minor; exit 0
+    let printVersion () = Version.(printf "obuild %d.%d.%d\n" major minor micro; exit 0)
         in
     let printHelp () = printf "a rescue team has been dispatched\n";
                        exit 0

--- a/src/version.ml
+++ b/src/version.ml
@@ -1,0 +1,3 @@
+let major = 0
+and minor = 0
+and micro = 0


### PR DESCRIPTION
After the initial bootstrap, we use the command 'obuild get version' to
generate the file src/version.ml, which is read when printing the version using
'obuild --version'.

Signed-off-by: Mike McClurg mike.mcclurg@citrix.com
