### PR TITLE
Allow obuild to be safe-string compatible

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 
-libs="unix.cmxa"
-OCAMLOPT="ocamlopt -g"
-# use faster ocamlopt, if available
-OCAMLOPT_OPT=`which ocamlopt.opt`
-if [[ $OCAMLOPT_OPT != "" ]] ; then
-    OCAMLOPT="ocamlopt.opt -g"
-fi
+libs="unix,bytes"
+OCAMLOPT="ocamlfind ocamlopt -g -package ${libs}"
 
 extmodules="fugue filepath filesystem"
 libmodules="types gconf filetype dag libname pp expr utils modname taskdep helper dagutils process findlibConf scheduler prog dependencies generators hier meta metacache target dist project analyze configure prepare buildprogs build exception"
@@ -74,7 +69,7 @@ do
 	APPEND+="${mod}.cmx "
 done
 echo "LINKING obuild.bootstrap"
-$OCAMLOPT -o ../obuild.bootstrap -I ../ ${libs} obuild_ext.cmxa obuild.cmxa $APPEND
+$OCAMLOPT -o ../obuild.bootstrap -I ../ -linkpkg obuild_ext.cmxa obuild.cmxa $APPEND
 cd ..
 
 rm -f obuild/*.cmi obuild/*.cmx obuild/*.o

--- a/ext/filesystem.ml
+++ b/ext/filesystem.ml
@@ -143,7 +143,7 @@ let readFile path =
         while not !isDone do
             let r = Unix.read fd b 0 1024 in
             if r > 0
-                then Buffer.add_subbytes buf b 0 r
+                then Buffer.add_substring buf (Bytes.to_string b) 0 r
                 else isDone := true
         done;
         Buffer.contents buf

--- a/obuild.obuild
+++ b/obuild.obuild
@@ -47,10 +47,10 @@ extra-srcs: bootstrap
 
 library obuild
   modules: obuild
-  build-deps: unix, obuild.ext
+  build-deps: unix, bytes, obuild.ext
   library ext
     modules: ext
-    build-deps: unix
+    build-deps: unix, bytes
 
 # a comment
 executable obuild

--- a/obuild/dag.ml
+++ b/obuild/dag.ml
@@ -110,7 +110,7 @@ let getChildren dag a = (getNode dag a).children
 
 let getParents dag a = (getNode dag a).parents
 
-let rec getChildren_full dag a = 
+let rec getChildren_full dag a =
     let children = getChildren dag a in
     children @ List.concat (List.map (getChildren_full dag) children)
 
@@ -191,13 +191,14 @@ let toDot a_to_string name fromLeaf dag =
     let nodes = getNodes dag in
     let dotIndex = Hashtbl.create (List.length nodes) in
     let append = Buffer.add_string buf in
-    let sanitizeName = String.copy name in
+    let sanitizeName = Bytes.of_string name in
     for i = 0 to String.length name - 1
     do
-        if sanitizeName.[i] = '-' then sanitizeName.[i] <- '_'
+      if Bytes.get sanitizeName i = '-' then
+        Bytes.set sanitizeName i '_';
     done;
 
-    append ("digraph " ^ sanitizeName ^ " {\n");
+    append ("digraph " ^ Bytes.to_string sanitizeName ^ " {\n");
 
     let list_iteri f list =
         let rec loop i l =
@@ -220,6 +221,6 @@ let toDot a_to_string name fromLeaf dag =
             append (sprintf "  %d -> %d;\n" i ci)
         ) ((if fromLeaf then getParents else getChildren) dag n)
     ) nodes;
-    
+
     append "}\n";
     Buffer.contents buf

--- a/obuild/dependencies.ml
+++ b/obuild/dependencies.ml
@@ -51,14 +51,15 @@ let runOcamldep dopt srcFile =
  * to take that in consideration.
 *)
 let joinLines s =
-  let s_end = String.length s in
+  let s = Bytes.of_string s in
+  let s_end = Bytes.length s in
   let rec replace start =
     try
-      let index = String.index_from s start '\\' in
+      let index = Bytes.index_from s start '\\' in
       if index < s_end - 1 then
-        if (String.get s (index + 1)) = '\n' then begin
-          String.set s index  ' ';
-          String.set s (index + 1) ' ';
+        if (Bytes.get s (index + 1)) = '\n' then begin
+          Bytes.set s index  ' ';
+          Bytes.set s (index + 1) ' ';
           replace (index + 2)
         end
         else
@@ -67,7 +68,7 @@ let joinLines s =
         s
     with Not_found -> s
   in
-  replace 0
+  Bytes.to_string (replace 0)
 
 let runCCdep srcDir files : (filename * filepath list) list =
   let args = [Prog.getCC (); "-MM"] @ List.map (fun fn -> fp_to_string (srcDir </> fn)) files in
@@ -77,4 +78,3 @@ let runCCdep srcDir files : (filename * filepath list) list =
     parse_output_KsemiVs
       (fun _ -> raise (BuildCDepAnalyzeFailed "missing semicolon in gcc dependency output"))
       fn fp (joinLines out)
-

--- a/obuild/process.ml
+++ b/obuild/process.ml
@@ -54,7 +54,7 @@ let wait processes =
   let is_finished (_, p) = p.err.closed && p.out.closed in
   let remove_from_list e list = List.filter (fun x -> x <> e) list in
   let process_loop () =
-    let b = String.create 1024 in
+    let b = Bytes.create 1024 in
     let live_processes = ref processes in
     let done_processes = ref None in
     let read_fds () = List.fold_left (fun acc (_, p) ->
@@ -68,7 +68,7 @@ let wait processes =
         if not out.closed && List.mem out.fd reads then
           let nb = Unix.read out.fd b 0 1024 in
           if nb > 0
-          then Buffer.add_substring out.buf b 0 nb
+          then Buffer.add_subbytes out.buf b 0 nb
           else (Unix.close out.fd; out.closed <- true; fds := read_fds ())
       in
       List.iter (fun (task, p) ->

--- a/obuild/process.ml
+++ b/obuild/process.ml
@@ -68,7 +68,7 @@ let wait processes =
         if not out.closed && List.mem out.fd reads then
           let nb = Unix.read out.fd b 0 1024 in
           if nb > 0
-          then Buffer.add_subbytes out.buf b 0 nb
+          then Buffer.add_substring out.buf (Bytes.to_string b) 0 nb
           else (Unix.close out.fd; out.closed <- true; fds := read_fds ())
       in
       List.iter (fun (task, p) ->

--- a/opam
+++ b/opam
@@ -8,3 +8,4 @@ maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]
 ]
+available: [ocaml-version >= "4.02.0"]

--- a/opam
+++ b/opam
@@ -8,4 +8,7 @@ maintainer: "jmaloberti@gmail.com"
 build: [
   ["./bootstrap"]
 ]
-available: [ocaml-version >= "4.02.0"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+]


### PR DESCRIPTION
Currently obuild doesn't compile with OCaml 4.06 or any OCaml releases with safe-string enabled.
This PR fixes this.

Unfortunately, I didn't managed to be compatible with OCaml < 4.02. If it's not a problem it can be merged, otherwise it requires some more work (if anybody want to give it a try).