### PR TITLE
Always sort readdir results in order to get reproducible builds

### DIFF
--- a/obuild/project.ml
+++ b/obuild/project.ml
@@ -440,7 +440,7 @@ let make = {
 }
 
 let findPath () =
-    let ents = Array.to_list (Sys.readdir ".") in
+    let ents = List.fast_sort String.compare (Array.to_list (Sys.readdir ".")) in
     match List.find_all (fun ent -> not (string_startswith "." ent) && string_endswith ".obuild" ent) ents with
     | []  -> raise NoConfFile
     | [x] -> fp x


### PR DESCRIPTION
Fix #175.
I verified the reproducibility of obuild itself with the method described in https://wiki.debian.org/ReproducibleBuilds/Howto#Newer_method