### PR TITLE
Handle line feed in META files

### DIFF
--- a/obuild/build.ml
+++ b/obuild/build.ml
@@ -367,7 +367,7 @@ let link_ task_index bstate cstate pkgDeps target dag compiled useThreadLib ccli
           if (satisfy_preds dep preds) then
             let archives = Meta.Pkg.get_archive_with_filter meta dep preds in
             List.fold_left (fun acc (_,a) ->
-                let files = string_split ' ' a in
+                let files = Meta.string_split_words a in
                 acc @ (List.map (fun f -> in_current_dir $ fn f) files)
               ) [] archives
           else

--- a/obuild/meta.ml
+++ b/obuild/meta.ml
@@ -217,6 +217,10 @@ type t = filepath * Pkg.t
 
 let path_warning = ref false
 
+let string_split_words s =
+  List.filter (fun x -> x <> "") $
+  string_split_pred (fun c -> List.mem c [','; ' '; '\n']) s
+
 module Token = struct
   (* mini lexer *)
   type t =
@@ -346,8 +350,7 @@ module Token = struct
         match xs2 with
         | PLUSEQ :: S reqs :: xs3
         | EQ :: S reqs :: xs3 ->
-          let deps = List.map (fun r -> Libname.of_string r)
-                     $ (List.filter (fun x -> x <> "") $ string_split_pred (fun c -> List.mem c [',';' ']) reqs)
+          let deps = List.map (fun r -> Libname.of_string r) $ string_split_words reqs
           in
           parse pkg_name { acc with Pkg.requires = (preds, (List.rev deps)) :: acc.Pkg.requires } xs3
         | _ -> raise (MetaParseError (pkg_name, "parsing requires failed"))


### PR DESCRIPTION
Previously, only spaces were handled as delimiters for splitting the
lists of packages in META files. However, other build systems, like
dune, use pretty-printers to generate META files that cause some lists
to be split into several lines, and obuild misinterpreted them as
packages with line feeds in their name.